### PR TITLE
fix: issue with missing templates/static folders via pypi run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 Python-based markdown preview server with live reload, themes, diagrams, and static export capabilities.
 
-[![Pytest](https://img.shields.io/badge/Pytest-fff?logo=pytest&labelColor=black&color=%237B2CBF)](#)
 [![GitHub Release](https://img.shields.io/github/v/release/eosho/markdpy?sytle=flat&label=Release&labelColor=black&color=%237B2CBF)](https://github.com/eosho/markdpy/releases)
 [![GitHub License](https://img.shields.io/github/license/eosho/markdpy?style=flat&label=License&labelColor=black&color=%237B2CBF)](LICENSE)
 [![GitHub Repo stars](https://img.shields.io/github/stars/eosho/markdpy?style=flat&logo=github&logoColor=white&label=Stars&labelColor=black&color=7B2CBF)](https://github.com/eosho/markdpy)
@@ -31,7 +30,13 @@ Python-based markdown preview server with live reload, themes, diagrams, and sta
 
 ## 📦 Installation
 
-### From source
+### From PyPI (Recommended)
+
+```bash
+pip install markdpy
+```
+
+### From Source
 
 ```bash
 git clone https://github.com/eosho/markdpy.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,19 @@ Issues = "https://github.com/eosho/markdpy/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/markdpy"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"static" = "markdpy/static"
+"templates" = "markdpy/templates"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/static",
+    "/templates",
+    "/README.md",
+    "/LICENSE",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
This pull request updates the installation instructions, improves packaging configuration, and makes minor changes to the project documentation. The most significant changes are improvements to how static assets and templates are included in builds, and clearer installation steps for users.

**Documentation updates:**

* Added a "From PyPI (Recommended)" section to the installation instructions in `README.md`, making it easier for users to install the package via `pip`.
* Removed the Pytest badge from the `README.md` for a cleaner project overview.

**Packaging improvements:**

* Updated `pyproject.toml` to ensure that the `static` and `templates` directories are included in both wheel and source distributions. This helps guarantee all necessary assets are packaged and available after installation.